### PR TITLE
Fixed bug that occured when moving between map and quantile tabs

### DIFF
--- a/src/components/pagination.js
+++ b/src/components/pagination.js
@@ -34,7 +34,6 @@ export const paginationHandler = (data, pageSize, headers) => {
   for (let i = 0; i < pages; i++) {
     array.push(i + 1);
   }
-  console.log('Sahar: ', {pages, dataLength, array, tt: document.getElementById("pages-container")})
   document.getElementById("pages-container").innerHTML = paginationTemplate(array, pageSize);
   addEventPageBTNs(pageSize, data, headers);
 };
@@ -122,7 +121,6 @@ export const paginationTemplate = (array, pageSize) => {
           </ul>
       </nav>
   `;
-  console.log('sahar: 2 ', {template})
   return template;
 };
 

--- a/src/utils/map.js
+++ b/src/utils/map.js
@@ -16,9 +16,11 @@ const LEVELS = ["state", "county"]
 
 // Note: Using standard object properties unless listeners required
 
-const state = new State
+let state;
 
 export async function start() {
+  state = new State()
+
   hookInputs()
   await loadData()
 

--- a/src/utils/mapPlots.js
+++ b/src/utils/mapPlots.js
@@ -140,7 +140,6 @@ export function createDemographicsPlot(data, options = {}) {
     fill: "#dedede", 
     pointerEvents: "none"
   }
-  console.log('Bar: ', {mainField, domainValues, otherField})
   if (otherField != "none") {
     barOptions.fx = otherField
     refTickOptions.fx = otherField

--- a/src/utils/quantiles.js
+++ b/src/utils/quantiles.js
@@ -14,10 +14,11 @@ import { toggleSidebar } from "./helper.js"
 const MEASURES = ["crude_rate", "age_adjusted_rate"]
 
 // Note: Using standard object properties unless listeners required
-const state = new State()
-
+let state;
 
 export async function start() {
+  state = new State()
+
   hookInputs()
   await loadData()
 


### PR DESCRIPTION
@Sahar-behpour noticed a bug where the tool would break if the user changed tabs. This was due to how the state and tabs were being handled. Global variables are maintained when changing tabs, and the state object was getting muddled. We now instantiate the state object every time the tab is changed. But later we should consider how we are handling tabs and how much should be maintained between tab changes. 